### PR TITLE
Version 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ which encodes most non-alphanumeric characters.
   is not supported and will throw an `UnserializableParamError`.
 - Serialization of functions or other objects is
   is not supported and will throw an `UnserializableParamError`.
+- Serialization of `NaN`, `Infinity`, and `-Infinity`
+  is not supported and will throw an `UnserializableParamError`.
 
 ### Compatible parsing strategy
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ Defines the standard for how the Seam SDKs and other Seam API consumers
 should serialize objects to [URLSearchParams] in HTTP GET requests.
 Serves as a reference implementation for Seam SDKs in other languages.
 
-See this test for the [serialization behavior](./test/serialization.test.ts).
+This serializer may be used as a true inverse operation to [@seamapi/url-search-params-parser][@url-search-params-parser].
 
 [URLSearchParams]: https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams
+[@url-search-params-parser]: https://github.com/seamapi/url-search-params-parser
 
 ### Serialization strategy
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@seamapi/url-search-params-serializer",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@seamapi/url-search-params-serializer",
-      "version": "2.0.0-beta.1",
+      "version": "2.0.0-beta.2",
       "license": "MIT",
       "devDependencies": {
         "@js-temporal/polyfill": "^0.4.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@seamapi/url-search-params-serializer",
-  "version": "1.3.0",
+  "version": "2.0.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@seamapi/url-search-params-serializer",
-      "version": "1.3.0",
+      "version": "2.0.0-beta.1",
       "license": "MIT",
       "devDependencies": {
         "@js-temporal/polyfill": "^0.4.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@seamapi/url-search-params-serializer",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@seamapi/url-search-params-serializer",
-      "version": "2.0.0-beta.2",
+      "version": "2.0.0-beta.1",
       "license": "MIT",
       "devDependencies": {
         "@js-temporal/polyfill": "^0.4.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seamapi/url-search-params-serializer",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.1",
   "description": "Serializes JavaScript objects to URLSearchParams.",
   "type": "module",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seamapi/url-search-params-serializer",
-  "version": "1.3.0",
+  "version": "2.0.0-beta.1",
   "description": "Serializes JavaScript objects to URLSearchParams.",
   "type": "module",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seamapi/url-search-params-serializer",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "Serializes JavaScript objects to URLSearchParams.",
   "type": "module",
   "main": "index.js",

--- a/src/lib/serialize.ts
+++ b/src/lib/serialize.ts
@@ -43,7 +43,11 @@ const nestedUpdateUrlSearchParams = (
     }
 
     if (Array.isArray(value)) {
-      if (value.length === 0) searchParams.set(name, '')
+      if (value.length === 0) {
+        searchParams.set(name, '')
+        continue
+      }
+
       if (value.length === 1 && value[0] === '') {
         throw new UnserializableParamError(
           name,

--- a/src/lib/serialize.ts
+++ b/src/lib/serialize.ts
@@ -1,7 +1,7 @@
 import { isDateLike, isTemporalInstantLike } from './date.js'
 import { isPlainObject } from './object.js'
 
-type Params = Record<string, unknown>
+export type Params = Record<string, unknown>
 
 export const serializeUrlSearchParams = (params: Params): string => {
   const searchParams = new URLSearchParams()

--- a/src/lib/serialize.ts
+++ b/src/lib/serialize.ts
@@ -83,7 +83,19 @@ const serialize = (k: string, v: unknown): string => {
     }
     return v.toString()
   }
-  if (typeof v === 'number') return v.toString()
+  if (typeof v === 'number') {
+    if (
+      isNaN(v) ||
+      v === Infinity ||
+      v === -Infinity ||
+      v.toString() === 'NaN' ||
+      v.toString() === 'Infinity' ||
+      v.toString() === '-Infinity'
+    ) {
+      throw new UnserializableParamError(k, `is ${v}`)
+    }
+    return v.toString()
+  }
   if (typeof v === 'bigint') return v.toString()
   if (typeof v === 'boolean') return v.toString()
   if (isDateLike(v)) return v.toISOString()

--- a/test/serialization.test.ts
+++ b/test/serialization.test.ts
@@ -125,6 +125,18 @@ test('cannot serialize functions', (t) => {
   })
 })
 
+test('cannot serialize number pointers', (t) => {
+  t.throws(() => serializeUrlSearchParams({ foo: Infinity }), {
+    instanceOf: UnserializableParamError,
+  })
+  t.throws(() => serializeUrlSearchParams({ foo: -Infinity }), {
+    instanceOf: UnserializableParamError,
+  })
+  t.throws(() => serializeUrlSearchParams({ foo: -NaN }), {
+    instanceOf: UnserializableParamError,
+  })
+})
+
 test('cannot serialize non-plain objects', (t) => {
   class Foo {
     bar: string


### PR DESCRIPTION
BREAKING CHANGE: The primitive value null will now be serialized instead
of removed, e.g., { foo: null } will now be serialized to 'foo='.